### PR TITLE
Hero: rotating install command + footer attribution

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -619,8 +619,18 @@ body {
   overflow-x: auto;
   scrollbar-width: none; /* long URL command scrolls quietly on narrow screens */
 }
-.dc-install__dollar {
-  color: var(--text-faint);
+/* The rotating slug: the outer span anchors it in the text run; the slot masks
+   the vertical roll and glides between slug widths (Motion animates width in ch)
+   so ".json" follows smoothly. Colour comes inline per icon (its glow). */
+.dc-install__slug {
+  display: inline-block;
+  vertical-align: bottom;
+}
+.dc-install__slug-slot {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 .dc-install__copy {
   display: inline-grid;
@@ -1053,6 +1063,29 @@ body {
   font-family: var(--ui-font);
   font-size: 13px;
   letter-spacing: 0;
+}
+/* "Crafted with Motion & Phosphor" attribution — the footer row's middle child,
+   centered by the space-between layout. Mono + chips so the two project names
+   read as quiet credits. */
+.dc-footer__credit {
+  font-family: var(--mono-font);
+}
+.dc-footer__credit-link {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-strong);
+  text-decoration: none;
+  transition: border-color 0.15s var(--ease), color 0.15s var(--ease);
+}
+.dc-footer__credit-link:hover {
+  border-color: var(--text-dim);
+  color: var(--text);
+}
+.dc-footer__credit-heart {
+  /* Keep the emoji from inheriting the muted text colour. */
+  filter: saturate(1.1);
 }
 .dc-footer__links {
   display: flex;

--- a/app/lab/basket/page.tsx
+++ b/app/lab/basket/page.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { forwardRef, useImperativeHandle } from "react";
+import { motion, type Variants } from "motion/react";
+import { useHover } from "@/hooks/use-hover";
+import { RETURN_TRANSITION } from "@/lib/motion-tokens";
+import type { IconHandle, IconProps } from "@/lib/icon";
+import { AT, OVERSHOOT, Svg, VariantGrid } from "@/app/lab/_shared/harness";
+
+/**
+ * LAB — Basket icon (Phosphor "shopping-basket"), 5 animation candidates.
+ *
+ * Reference videos studied first:
+ *   shopping-basket.mp4      — the top rim/handle rocks side to side and settles.
+ *   shopping-basket (2).mp4  — items drop into the basket from above and sink in
+ *                              while it gives a gentle rock.
+ *
+ * The glyph splits into its own untouched subpaths, so SHELL + GRIPS is
+ * byte-identical to the original:
+ *   SHELL — the basket body, the ^ carry handle, and the top rim (the outer
+ *           shell, its inner rim outline, and the handle triangle).
+ *   GRIPS — the three rounded content lines inside the basket.
+ */
+const SHELL =
+  "M239.93,89.06,224.86,202.12A16.06,16.06,0,0,1,209,216H47a16.06,16.06,0,0,1-15.86-13.88L16.07,89.06A8,8,0,0,1,24,80H68.37L122,18.73a8,8,0,0,1,12,0L187.63,80H232a8,8,0,0,1,7.93,9.06ZM89.63,80h76.74L128,36.15ZM222.86,96H33.14L47,200H209Z";
+const GRIPS =
+  "M136,120v56a8,8,0,0,1-16,0V120a8,8,0,0,1,16,0Zm36.84-.8-5.6,56A8,8,0,0,0,174.4,184a7.32,7.32,0,0,0,.81,0,8,8,0,0,0,7.95-7.2l5.6-56a8,8,0,0,0-15.92-1.6Zm-89.68,0a8,8,0,0,0-15.92,1.6l5.6,56a8,8,0,0,0,8,7.2,7.32,7.32,0,0,0,.81,0,8,8,0,0,0,7.16-8.76Z";
+
+const BASE = AT(128, 208); // basket floor — pivot for rocks & hops
+const APEX = AT(128, 36); //  top of the carry handle — pivot for the carry swing
+const GRIP_FOOT = AT(128, 176); // where the content lines sit — pivot for their settle
+
+/* ── 1. ROCK (from shopping-basket.mp4) ──────────────────────────────────────
+   The basket tips side to side on its base, so the rim and handle swing widest
+   — a decaying seesaw that settles level. */
+const rock: Variants = {
+  normal: { rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    rotate: [0, -7, 6, -3.5, 1.5, 0],
+    transition: { duration: 1.0, ease: "easeInOut", times: [0, 0.22, 0.46, 0.68, 0.86, 1] },
+  },
+};
+
+const BasketRockIcon = forwardRef<IconHandle, IconProps>(
+  function BasketRockIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : rock} style={BASE}>
+            <path d={SHELL} />
+            <path d={GRIPS} />
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 2. FILL (from shopping-basket (2).mp4) ──────────────────────────────────
+   Two items drop into the mouth from above and sink in; the basket gives a
+   little squash as each one lands. */
+const fillBasket: Variants = {
+  normal: { scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    scaleY: [1, 1, 0.94, 1.02, 1, 0.95, 1.01, 1],
+    scaleX: [1, 1, 1.04, 0.99, 1, 1.03, 0.99, 1],
+    transition: { duration: 1.2, ease: "easeInOut", times: [0, 0.24, 0.34, 0.48, 0.6, 0.72, 0.84, 1] },
+  },
+};
+// An item: waits, then falls from above into the mouth and fades as it sinks in.
+const item = (delay: number): Variants => ({
+  normal: { y: -52, opacity: 0, transition: { duration: 0.15 } },
+  animate: {
+    y: [-52, -52, 6, 12],
+    opacity: [0, 1, 1, 0],
+    transition: { duration: 0.9, ease: "easeIn", times: [0, 0.12, 0.8, 1], delay },
+  },
+});
+
+const BasketFillIcon = forwardRef<IconHandle, IconProps>(
+  function BasketFillIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          {/* Items fall behind the shell, which is drawn on top. Hidden at rest. */}
+          {!reduced && (
+            <>
+              <motion.circle cx={104} cy={104} r={13} variants={item(0)} />
+              <motion.circle cx={150} cy={104} r={11} variants={item(0.38)} />
+            </>
+          )}
+          <motion.g variants={reduced ? undefined : fillBasket} style={BASE}>
+            <path d={SHELL} />
+            <path d={GRIPS} />
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 3. SWING ────────────────────────────────────────────────────────────────
+   Carried by the handle: the whole basket swings as a decaying pendulum about
+   the top of the carry handle. */
+const swing: Variants = {
+  normal: { rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    rotate: [0, -10, 7.5, -4, 2, 0],
+    transition: { duration: 1.05, ease: "easeInOut", times: [0, 0.2, 0.45, 0.68, 0.86, 1] },
+  },
+};
+
+const BasketSwingIcon = forwardRef<IconHandle, IconProps>(
+  function BasketSwingIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : swing} style={APEX}>
+            <path d={SHELL} />
+            <path d={GRIPS} />
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 4. SETTLE ───────────────────────────────────────────────────────────────
+   The contents settle: the three content lines drop and jiggle a touch, staged
+   left-to-right, while the basket itself holds still. */
+const settle = (delay: number): Variants => ({
+  normal: { y: 0, scaleY: 1, transition: RETURN_TRANSITION },
+  animate: {
+    y: [0, -4, 2, -1, 0],
+    scaleY: [1, 0.9, 1.05, 0.98, 1],
+    transition: { duration: 0.8, ease: "easeOut", times: [0, 0.25, 0.5, 0.75, 1], delay },
+  },
+});
+
+const BasketSettleIcon = forwardRef<IconHandle, IconProps>(
+  function BasketSettleIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <path d={SHELL} />
+          {/* The three content lines settle together, jostling about their feet. */}
+          <motion.path d={GRIPS} variants={reduced ? undefined : settle(0)} style={GRIP_FOOT} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 5. HOP ──────────────────────────────────────────────────────────────────
+   A happy little jump: stretch on the way up, squash on the landing, settle —
+   pleased with what it's carrying.
+   Bounds: glyph top ≈ y16.7; stretch about the base then lift must keep it ≥0
+   or the wrapper's overflow:hidden clips the handle at the hop's peak.
+   scaleY 1.02 about y208 puts the top at 12.9; −11 lift lands it at 1.9 — the
+   extra unit absorbs the OVERSHOOT bezier's ~4% mid-segment overshoot. */
+const hop: Variants = {
+  normal: { y: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    y: [0, -11, 0, 0],
+    scaleY: [1, 1.02, 0.9, 1],
+    scaleX: [1, 0.98, 1.07, 1],
+    transition: { duration: 0.62, ease: OVERSHOOT, times: [0, 0.35, 0.7, 1] },
+  },
+};
+
+const BasketHopIcon = forwardRef<IconHandle, IconProps>(
+  function BasketHopIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : hop} style={BASE}>
+            <path d={SHELL} />
+            <path d={GRIPS} />
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 6. SWING + HOP ──────────────────────────────────────────────────────────
+   The two gestures as one continuous move: the basket springs up with a
+   stretch, swings like a pendulum while airborne, then lands with the squash
+   and settles. Two nested groups so each motion keeps its own pivot — the hop
+   about the base, the swing about the handle apex. */
+const SH_DUR = 1.3;
+const shHop: Variants = {
+  normal: { y: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    // Up fast, hang airborne through the middle (while the swing plays), then
+    // land with the squash and recover. Same bounds budget as HOP: stretch
+    // about the base then lift must keep the glyph top (y16.7) ≥ 0, or the
+    // wrapper's overflow:hidden clips the handle at the peak.
+    y: [0, -12, -11, -11, 0, 0],
+    scaleY: [1, 1.02, 1, 1, 0.9, 1],
+    scaleX: [1, 0.98, 1, 1, 1.07, 1],
+    transition: { duration: SH_DUR, ease: "easeInOut", times: [0, 0.16, 0.24, 0.6, 0.78, 1] },
+  },
+};
+const shSwing: Variants = {
+  normal: { rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    // Swings only while airborne (the middle of the timeline), level by landing.
+    rotate: [0, 0, -9, 7, -3.5, 0, 0],
+    transition: { duration: SH_DUR, ease: "easeInOut", times: [0, 0.14, 0.3, 0.46, 0.6, 0.74, 1] },
+  },
+};
+
+const BasketSwingHopIcon = forwardRef<IconHandle, IconProps>(
+  function BasketSwingHopIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : shHop} style={BASE}>
+            <motion.g variants={reduced ? undefined : shSwing} style={APEX}>
+              <path d={SHELL} />
+              <path d={GRIPS} />
+            </motion.g>
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 7. SWING + HOP + SETTLE ─────────────────────────────────────────────────
+   v6 with consequences: the basket springs up, swings while airborne, lands —
+   and the impact jostles the contents, which drop and jiggle to rest a beat
+   after touchdown. The grips ride inside both gesture groups (so they travel
+   with the basket) and play the settle about their own feet on landing.
+   Landing is at SH_DUR × 0.78 ≈ 1.0s, so the settle delays until just then. */
+const shsSettle: Variants = {
+  normal: { y: 0, scaleY: 1, transition: RETURN_TRANSITION },
+  animate: {
+    y: [0, -4, 2, -1, 0],
+    scaleY: [1, 0.9, 1.05, 0.98, 1],
+    transition: { duration: 0.55, ease: "easeOut", times: [0, 0.25, 0.5, 0.75, 1], delay: SH_DUR * 0.74 },
+  },
+};
+
+const BasketSwingHopSettleIcon = forwardRef<IconHandle, IconProps>(
+  function BasketSwingHopSettleIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : shHop} style={BASE}>
+            <motion.g variants={reduced ? undefined : shSwing} style={APEX}>
+              <path d={SHELL} />
+              <motion.path d={GRIPS} variants={reduced ? undefined : shsSettle} style={GRIP_FOOT} />
+            </motion.g>
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── Preview grid ──────────────────────────────────────────────────────────── */
+
+const VARIANTS: { name: string; blurb: string; Component: typeof BasketRockIcon }[] = [
+  { name: "Rock", blurb: "Tips side to side, rim swings widest (shopping-basket.mp4)", Component: BasketRockIcon },
+  { name: "Fill", blurb: "Items drop into the mouth, basket squashes (shopping-basket (2).mp4)", Component: BasketFillIcon },
+  { name: "Swing", blurb: "Carried by the handle — decaying pendulum", Component: BasketSwingIcon },
+  { name: "Settle", blurb: "The contents drop and jiggle, basket holds still", Component: BasketSettleIcon },
+  { name: "Hop", blurb: "Happy jump — stretch up, squash on landing", Component: BasketHopIcon },
+  { name: "Swing + Hop", blurb: "Springs up, swings while airborne, lands & settles", Component: BasketSwingHopIcon },
+  { name: "Swing + Hop + Settle", blurb: "The full trip — and the landing jostles the contents", Component: BasketSwingHopSettleIcon },
+];
+
+export default function BasketLabPage() {
+  return <VariantGrid title="Basket" variants={VARIANTS} cycleMs={2800} playMs={1600} />;
+}

--- a/app/lab/basketball/page.tsx
+++ b/app/lab/basketball/page.tsx
@@ -1,0 +1,351 @@
+"use client";
+
+import { forwardRef, useImperativeHandle } from "react";
+import { motion, type Variants } from "motion/react";
+import { useHover } from "@/hooks/use-hover";
+import { RETURN_TRANSITION } from "@/lib/motion-tokens";
+import type { IconHandle, IconProps } from "@/lib/icon";
+import { AT, OVERSHOOT, Svg, VariantGrid } from "@/app/lab/_shared/harness";
+
+/**
+ * LAB — Basketball icon (Phosphor "basketball"), 5 animation candidates.
+ *
+ * The glyph is a ball whose 8 seam panels are part of the single compound path,
+ * so the whole ball moves as one — and rotation is the star: unlike most
+ * glyphs, you can SEE a basketball spin because the seams travel.
+ *
+ * Bounds: the circle spans y 24..232 and x 24..232, leaving 24 grid units of
+ * margin all round. Lifts and rolls below stay inside that budget (wrapper
+ * divs clip via overflow:hidden).
+ */
+const BALL =
+  "M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM60,72.17A87.2,87.2,0,0,1,79.63,120H40.37A87.54,87.54,0,0,1,60,72.17ZM136,120V40.37a87.59,87.59,0,0,1,48.68,20.37A103.06,103.06,0,0,0,160.3,120Zm-16,0H95.7A103.06,103.06,0,0,0,71.32,60.74,87.59,87.59,0,0,1,120,40.37ZM79.63,136A87.2,87.2,0,0,1,60,183.83,87.54,87.54,0,0,1,40.37,136Zm16.07,0H120v79.63a87.59,87.59,0,0,1-48.68-20.37A103.09,103.09,0,0,0,95.7,136Zm40.3,0h24.3a103.09,103.09,0,0,0,24.38,59.26A87.59,87.59,0,0,1,136,215.63Zm40.37,0h39.26A87.54,87.54,0,0,1,196,183.83,87.2,87.2,0,0,1,176.37,136Zm0-16A87.2,87.2,0,0,1,196,72.17,87.54,87.54,0,0,1,215.63,120Z";
+
+const CENTER = AT(128, 128); // ball center — spin pivot
+const FLOOR = AT(128, 232); //  bottom of the ball — bounce/squash pivot
+
+/* ── 1. BOUNCE ───────────────────────────────────────────────────────────────
+   One real dribble: the ball lifts, drops, squashes hard on the floor, pops
+   back up smaller, and settles — decaying like a live ball. */
+const bounce: Variants = {
+  normal: { y: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    y: [0, -18, 0, -8, 0, 0],
+    scaleY: [1, 1.02, 0.85, 1.01, 0.94, 1],
+    scaleX: [1, 0.99, 1.1, 1, 1.04, 1],
+    transition: { duration: 0.9, ease: "easeInOut", times: [0, 0.2, 0.42, 0.62, 0.8, 1] },
+  },
+};
+
+const BasketballBounceIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballBounceIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.path d={BALL} variants={reduced ? undefined : bounce} style={FLOOR} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 2. DRIBBLE ──────────────────────────────────────────────────────────────
+   Two quick low taps — the hand keeping the ball alive. Faster rhythm and
+   smaller travel than BOUNCE, each contact a light squash. */
+const dribble: Variants = {
+  normal: { y: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    y: [0, -10, 0, -10, 0, 0],
+    scaleY: [1, 1, 0.92, 1, 0.92, 1],
+    scaleX: [1, 1, 1.05, 1, 1.05, 1],
+    transition: { duration: 0.75, ease: "easeInOut", times: [0, 0.18, 0.36, 0.58, 0.78, 1] },
+  },
+};
+
+const BasketballDribbleIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballDribbleIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.path d={BALL} variants={reduced ? undefined : dribble} style={FLOOR} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 3. SPIN ─────────────────────────────────────────────────────────────────
+   On the fingertip: a full revolution with a fast launch that drains to a
+   stop — the seams do all the talking. */
+const spin: Variants = {
+  normal: { rotate: 0, transition: { duration: 0 } },
+  animate: {
+    rotate: [0, 360],
+    transition: { duration: 0.9, ease: [0.2, 0.6, 0.3, 1] },
+  },
+};
+
+const BasketballSpinIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballSpinIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.path d={BALL} variants={reduced ? undefined : spin} style={CENTER} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 4. SHOT ─────────────────────────────────────────────────────────────────
+   The jump shot: the ball rises with backspin (opposite the arc, like a real
+   release), hangs at the top of the arc, and drops back to the set point. */
+const shot: Variants = {
+  normal: { y: 0, rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    // y keeps its keyframes (the hang at the top of the arc is intentional);
+    // rotation is ONE segment with its own curve — per-segment easing would
+    // stall the backspin at every keyframe boundary.
+    y: [0, -18, -20, -4, 0],
+    rotate: [0, -360],
+    transition: {
+      duration: 0.95,
+      y: { ease: "easeInOut", times: [0, 0.32, 0.5, 0.85, 1] },
+      rotate: { ease: [0.4, 0.12, 0.3, 1] },
+    },
+  },
+};
+
+const BasketballShotIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballShotIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.path d={BALL} variants={reduced ? undefined : shot} style={CENTER} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 5. ROLL ─────────────────────────────────────────────────────────────────
+   Rolls away and back along the floor, rotation matched to travel so the
+   seams grip the ground instead of sliding (x = rθ: 14 units ≈ 8° on r104). */
+const roll: Variants = {
+  normal: { x: 0, rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    x: [0, -14, 10, -4, 0],
+    rotate: [0, -8, 5.5, -2, 0],
+    transition: { duration: 1.0, ease: "easeInOut", times: [0, 0.28, 0.56, 0.8, 1] },
+  },
+};
+
+const BasketballRollIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballRollIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          {/* CENTER, not FLOOR: a rolling ball rotates about its own center
+              while translating. A floor pivot adds lateral drift on top of the
+              x-travel and pushes the ball out of the viewBox. */}
+          <motion.path d={BALL} variants={reduced ? undefined : roll} style={CENTER} />
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 6. SPLAT (from basketball.mp4) ──────────────────────────────────────────
+   The video's motion, frame-studied: a slight lean of anticipation, then the
+   ball squashes down HARD — seams crumpling toward the floor — springs back up
+   through a tall stretch, and settles with a decaying seam-sway. The seams are
+   negative space in the compound path (they can't crumple independently), so
+   the crumple reads through the deep floor-pivot squash and the sway through a
+   rotate wobble about the center — two nested groups, each on its own pivot.
+   Bounds: scaleX 1.18 keeps edges at x 5.3/250.7; scaleY 1.08 about the floor
+   puts the top at 7.4 — all inside the 0..256 box. */
+const SPLAT_DUR = 1.15;
+const splatSquash: Variants = {
+  normal: { x: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    x: [0, -3, 0, 0, 0, 0, 0],
+    scaleY: [1, 0.98, 0.72, 1.08, 0.95, 1.02, 1],
+    scaleX: [1, 1.01, 1.18, 0.94, 1.04, 0.99, 1],
+    transition: { duration: SPLAT_DUR, ease: "easeInOut", times: [0, 0.13, 0.3, 0.5, 0.68, 0.85, 1] },
+  },
+};
+const splatSway: Variants = {
+  normal: { rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    // The seams settling after the recovery — still through the squash, then a
+    // decaying wobble once the ball is round again.
+    rotate: [0, 0, 3.5, -2.5, 1, 0],
+    transition: { duration: SPLAT_DUR, ease: "easeInOut", times: [0, 0.42, 0.58, 0.74, 0.88, 1] },
+  },
+};
+
+const BasketballSplatIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballSplatIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : splatSquash} style={FLOOR}>
+            <motion.g variants={reduced ? undefined : splatSway} style={CENTER}>
+              <path d={BALL} />
+            </motion.g>
+          </motion.g>
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 7. SPIN + BOUNCE (from basketball.mp4, frame-studied) ───────────────────
+   The video layers two synchronized motions plus a flourish:
+     bounce — pure deformation: tall stretch at 0.16s (wind-up), wide squash at
+              0.44s (contact), counter-stretch recovery, breathing settle.
+     spin   — the seams travel once around the sphere, launching after the
+              wind-up and crossing the equator EXACTLY at max squash.
+     whips  — elastic seam-tails lash around the outside of the ball during the
+              fast part of the spin, trailing behind and fading as it drains.
+   The ball's spin nests INSIDE the deformation (mid-spin seams pass through
+   squashed space and bow — the video's "waffle" moment). The whip-tails are
+   NEW INK: two arc streaks at r114 orbiting with a rotation that lags the
+   ball (elastic trail), visible only mid-spin, gone at rest.
+   Bounds: ball — scaleY 1.08 about y232 → top 7.4; scaleX 1.12 → x 11.5/244.5.
+   Streaks sit OUTSIDE the squash group on purpose: squashed, their r120 outer
+   edge would cross x=0; undeformed they orbit at 8..248. All inside the box. */
+const SB_DUR = 1.25;
+const sbBounce: Variants = {
+  normal: { scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    scaleY: [1, 1.08, 1, 0.85, 1.04, 0.98, 1],
+    scaleX: [1, 0.94, 1, 1.12, 0.97, 1.01, 1],
+    transition: { duration: SB_DUR, ease: "easeInOut", times: [0, 0.14, 0.3, 0.44, 0.62, 0.8, 1] },
+  },
+};
+const sbSpin: Variants = {
+  normal: { rotate: 0, transition: { duration: 0 } },
+  animate: {
+    // ONE segment, one bezier — multiple keyframes would apply the easing per
+    // segment and halt the rotation at every boundary (visible stutter). The
+    // curve itself does the sync: slow launch out of the wind-up, fastest
+    // through the middle (≈180° lands near the squash at t≈0.44), long drain.
+    rotate: [0, 360],
+    transition: { duration: SB_DUR, ease: [0.55, 0.08, 0.25, 1] },
+  },
+};
+/* Trail frame: same single-segment rule, on a lazier curve — it falls behind
+   the ball through the fast phase (the elastic tails trailing the spin) and
+   converges by the end. */
+const sbTrail: Variants = {
+  normal: { rotate: 0, transition: { duration: 0 } },
+  animate: {
+    rotate: [0, 360],
+    transition: { duration: SB_DUR, ease: [0.72, 0.05, 0.22, 1] },
+  },
+};
+const sbStreak: Variants = {
+  normal: { opacity: 0, pathLength: 0.3, transition: { duration: 0 } },
+  animate: {
+    // Whips exist only while the spin is fast: grow in, stretch long, snap out.
+    opacity: [0, 0, 1, 1, 0.6, 0],
+    pathLength: [0.15, 0.15, 1, 1, 0.4, 0.15],
+    transition: { duration: SB_DUR, ease: "easeInOut", times: [0, 0.18, 0.32, 0.55, 0.72, 0.85] },
+  },
+};
+// Arcs of the r114 circle about (128,128): lower-left 100°→150°, upper-right
+// 280°→330° (θ increasing = clockwise in y-down coords, hence sweep=1).
+const STREAK_A = "M108.2,240.3 A114,114 0 0 1 29.3,185";
+const STREAK_B = "M147.8,15.7 A114,114 0 0 1 226.7,71";
+
+const BasketballSpinBounceIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballSpinBounceIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : sbBounce} style={FLOOR}>
+            <motion.g variants={reduced ? undefined : sbSpin} style={CENTER}>
+              <path d={BALL} />
+            </motion.g>
+          </motion.g>
+          {!reduced && (
+            <motion.g variants={sbTrail} style={CENTER}>
+              <motion.path d={STREAK_A} variants={sbStreak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+              <motion.path d={STREAK_B} variants={sbStreak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+            </motion.g>
+          )}
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── 8. WHIP (from basketball.mp4 — the 3D seam-tails, circled frames) ───────
+   Same synchronized motion as SPIN + BOUNCE, but the tails are drawn the way
+   the video draws them: as SEAM CONTINUATIONS, not orbit arcs. Each starts
+   INSIDE the ball hugging a latitude curve, crosses the rim, and flicks off
+   tangentially with the tip bowing the opposite way — that S-curve against the
+   sphere's curvature is what makes it read as 3D. Placed at the video's two
+   positions (right of the equator, lower-right); the lagging trail group
+   sweeps them around the ball. pathLength draws inner→tip, so each whip grows
+   off the surface in the direction of travel and retracts as the spin drains.
+   Bounds: tips reach r≈110–115 (+6 stroke ≈ 121) → rotating extremes 7..249,
+   inside the box; the tails sit outside the squash group like v7's streaks. */
+const WHIP_A = "M136,148 C176,164 206,160 238,130";
+const WHIP_B = "M112,204 C156,220 196,216 224,192";
+
+const BasketballWhipIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballWhipIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <Svg size={size} controls={controls}>
+          <motion.g variants={reduced ? undefined : sbBounce} style={FLOOR}>
+            <motion.g variants={reduced ? undefined : sbSpin} style={CENTER}>
+              <path d={BALL} />
+            </motion.g>
+          </motion.g>
+          {!reduced && (
+            <motion.g variants={sbTrail} style={CENTER}>
+              <motion.path d={WHIP_A} variants={sbStreak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+              <motion.path d={WHIP_B} variants={sbStreak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+            </motion.g>
+          )}
+        </Svg>
+      </div>
+    );
+  },
+);
+
+/* ── Preview grid ──────────────────────────────────────────────────────────── */
+
+const VARIANTS: { name: string; blurb: string; Component: typeof BasketballBounceIcon }[] = [
+  { name: "Bounce", blurb: "One real dribble — hard squash, decaying pop-up", Component: BasketballBounceIcon },
+  { name: "Dribble", blurb: "Two quick low taps, light squash on each contact", Component: BasketballDribbleIcon },
+  { name: "Spin", blurb: "Fingertip spin — a full turn, seams do the talking", Component: BasketballSpinIcon },
+  { name: "Shot", blurb: "Jump shot — rises with backspin, hangs, drops home", Component: BasketballShotIcon },
+  { name: "Roll", blurb: "Rolls away and back, rotation matched to travel", Component: BasketballRollIcon },
+  { name: "Splat", blurb: "Hard squash, tall recovery, seams sway to rest (basketball.mp4)", Component: BasketballSplatIcon },
+  { name: "Spin + Bounce", blurb: "Full turn through the squash, whip-tails lash & fade (basketball.mp4)", Component: BasketballSpinBounceIcon },
+  { name: "Whip", blurb: "Seam-tails wrap the sphere and flick off — the 3D read (basketball.mp4)", Component: BasketballWhipIcon },
+];
+
+export default function BasketballLabPage() {
+  return <VariantGrid title="Basketball" variants={VARIANTS} cycleMs={2800} playMs={1500} />;
+}

--- a/components/dark/gallery.tsx
+++ b/components/dark/gallery.tsx
@@ -155,7 +155,7 @@ export function Gallery({ icons }: { icons: IconView[] }) {
 
       {/* hero — tile scatter (Fintech Web Template), icons animate on hover */}
       <HeroTiles
-        onCopyInstall={(pm) => action("copy-cli", "bell", "Bell", pm)}
+        onCopyInstall={(pm, slug, name) => action("copy-cli", slug, name, pm)}
         onOpenSearch={() => setPaletteOpen(true)}
       />
 
@@ -227,6 +227,19 @@ export function Gallery({ icons }: { icons: IconView[] }) {
         {/* minimal site footer — copyright left, follow links right */}
         <footer className="dc-footer">
           <span className="dc-footer__copy">© {new Date().getFullYear()} Iconimate</span>
+          {/* Attribution: the two projects Iconimate is built on. Middle child of
+              the space-between row, so it sits centered between copy and links. */}
+          <span className="dc-footer__credit">
+            Crafted with{" "}
+            <a className="dc-footer__credit-link" href="https://github.com/motiondivision/motion" target="_blank" rel="noopener noreferrer">
+              Motion
+            </a>{" "}
+            &amp;{" "}
+            <a className="dc-footer__credit-link" href="https://github.com/phosphor-icons/core" target="_blank" rel="noopener noreferrer">
+              Phosphor
+            </a>{" "}
+            with <span className="dc-footer__credit-heart" aria-label="love" role="img">❤️</span>
+          </span>
           <nav className="dc-footer__links" aria-label="Follow me">
             <a href="https://x.com/Ammar110_SM" target="_blank" rel="noreferrer">
               X

--- a/components/dark/hero-tiles.tsx
+++ b/components/dark/hero-tiles.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
-import { motion, useReducedMotion, type Variants } from "motion/react";
+import { AnimatePresence, motion, useReducedMotion, type Variants } from "motion/react";
 import { BorderBeam } from "border-beam";
-import { visibleIconMeta, type IconMetaEntry } from "@/registry/icon-meta.gen";
+import { iconMeta, visibleIconMeta, type IconMetaEntry } from "@/registry/icon-meta.gen";
 import { LAZY_ICONS } from "@/registry/lazy-icons.gen";
 import type { IconHandle } from "@/lib/icon";
-import { installCommand, metaFor, PACKAGE_MANAGERS, type PackageManager } from "./icon-meta";
+import { installCommandParts, metaFor, PACKAGE_MANAGERS, type PackageManager } from "./icon-meta";
+
+// The slug that rotates through the hero install command. A hand-picked set of
+// recognisable icons, validated against the registry so a rename can't leave a
+// dead command (falls back to the first visible icons if the list ever drifts).
+const INSTALL_ROTATION_SLUGS = [
+  "bell", "heart", "airplane", "alarm", "anchor", "camera", "axe", "bank", "acorn", "cloud",
+];
 
 /*
  * The tile hero — a centered headline flanked by two 6×6 scatter grids of icon
@@ -35,6 +42,7 @@ const HERO = {
   tilePop: { type: "spring", visualDuration: 0.5, bounce: 0.34 } as const,
   ambientEvery: 2600, // ms between ambient icon plays
   ambientPlay: 1400, // ms an ambient play runs before gliding home
+  installRotateEvery: 2400, // ms the install command holds on each icon slug
 };
 
 // (The center lockup's rise is CSS — .fh-rise in globals.css — so the LCP text
@@ -187,8 +195,8 @@ export function HeroTiles({
   onCopyInstall,
   onOpenSearch,
 }: {
-  /** Copy the hero install command for the given package manager. */
-  onCopyInstall: (pm: PackageManager) => void;
+  /** Copy the hero install command for the currently shown icon + package manager. */
+  onCopyInstall: (pm: PackageManager, slug: string, name: string) => void;
   onOpenSearch: () => void;
 }) {
   const [pm, setPm] = useState<PackageManager>("npm");
@@ -223,6 +231,37 @@ export function HeroTiles({
       window.clearTimeout(stopTimer);
     };
   }, [reduceMotion]);
+
+  // The install command's slug cycles through a curated set, so the CLI bar
+  // advertises the breadth of the library instead of one fixed icon. Validated
+  // against the registry so a removed icon can't leave a dead command.
+  const rotation = useMemo<IconMetaEntry[]>(() => {
+    const bySlug = new Map(iconMeta.map((e) => [e.slug, e]));
+    const picked = INSTALL_ROTATION_SLUGS.map((s) => bySlug.get(s)).filter(
+      (e): e is IconMetaEntry => Boolean(e),
+    );
+    return picked.length >= 3 ? picked : visibleIconMeta.slice(0, 8);
+  }, []);
+  const [rotIndex, setRotIndex] = useState(0);
+  const current = rotation[rotIndex % rotation.length];
+
+  // Advance the slug on an interval. Frozen under reduced motion (stays on the
+  // first icon), and paused while the field is hovered (beamOn) so you always
+  // copy exactly the icon you see — no swap can race the click.
+  useEffect(() => {
+    if (reduceMotion || beamOn || rotation.length < 2) return;
+    const id = window.setInterval(
+      () => setRotIndex((i) => (i + 1) % rotation.length),
+      HERO.installRotateEvery,
+    );
+    return () => window.clearInterval(id);
+  }, [reduceMotion, beamOn, rotation.length]);
+
+  const { before, after } = installCommandParts(pm);
+  // Reserve the widest slug's width up front (GeistMono, so 1 char = 1ch): the
+  // bar's size is then constant across the whole rotation — no width jitter on
+  // each swap, and no wrap on long pm prefixes shifting the hero vertically.
+  const slugCh = useMemo(() => Math.max(...rotation.map((e) => e.slug.length)), [rotation]);
 
   return (
     <section className="fh">
@@ -267,13 +306,49 @@ export function HeroTiles({
                 onMouseLeave={() => setBeamOn(false)}
               >
                 <span className="dc-install dc-mono">
-                  <span className="dc-install__dollar">$</span>
-                  <span className="dc-install__cmd">{installCommand("bell", pm)}</span>
+                  {/* The box is pinned to the widest command in the rotation
+                      (GeistMono: 1 char = 1ch), so nothing outside it ever moves
+                      — no width jitter per swap, no wrap shifting the hero
+                      vertically. Inside, the slug slot glides between slug
+                      widths so ".json" follows smoothly instead of snapping. */}
+                  <span
+                    className="dc-install__cmd"
+                    style={{ minWidth: `${before.length + slugCh + after.length}ch` }}
+                  >
+                    {before}
+                    {reduceMotion ? (
+                      current.slug
+                    ) : (
+                      <span className="dc-install__slug">
+                        <motion.span
+                          className="dc-install__slug-slot"
+                          animate={{ width: `${current.slug.length}ch` }}
+                          transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+                        >
+                          <AnimatePresence mode="wait" initial={false}>
+                            {/* Each name rolls up into place in its icon's own
+                                glow colour. */}
+                            <motion.span
+                              key={current.slug}
+                              initial={{ y: "0.9em", opacity: 0 }}
+                              animate={{ y: 0, opacity: 1 }}
+                              exit={{ y: "-0.9em", opacity: 0 }}
+                              transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+                              style={{ display: "inline-block", color: metaFor(current.slug).glow }}
+                            >
+                              {current.slug}
+                            </motion.span>
+                          </AnimatePresence>
+                        </motion.span>
+                      </span>
+                    )}
+                    {after}
+                  </span>
                   <button
                     type="button"
                     className="dc-install__copy"
-                    aria-label="Copy install command"
-                    onClick={() => onCopyInstall(pm)}
+                    aria-label={`Copy install command for ${current.name}`}
+                    onClick={() => onCopyInstall(pm, current.slug, current.name)}
                   >
                     <CopyGlyph />
                   </button>

--- a/components/dark/icon-meta.ts
+++ b/components/dark/icon-meta.ts
@@ -171,6 +171,8 @@ export const ICON_META: Record<string, IconMeta> = {
   baseball: { motion: "strikeout", glow: "#F87171" },
   "baseball-cap": { motion: "gust away", glow: "#60A5FA" },
   "baseball-helmet": { motion: "dizzy", glow: "#C084FC" },
+  basket: { motion: "jostle", glow: "#F59E0B" },
+  basketball: { motion: "spin + bounce", glow: "#FB923C" },
   "arrows-left-right": { motion: "bounce", glow: "#2DD4BF" },
   "arrow-elbow-down-left": { motion: "draw", glow: "#34D399" },
   "arrow-elbow-down-right": { motion: "draw", glow: "#34D399" },

--- a/components/dark/icon-meta.ts
+++ b/components/dark/icon-meta.ts
@@ -220,6 +220,20 @@ export function installCommand(slug: string, pm: PackageManager = "npm"): string
   return `${PM_RUNNER[pm]} shadcn@latest add ${registryUrl(slug)}`;
 }
 
+/**
+ * The install line split around the icon slug: `before + slug + after` equals
+ * installCommand(slug, pm). Lets the hero animate only the slug while the rest of
+ * the command stays fixed. Derived from installCommand via a sentinel so the
+ * command format lives in exactly one place.
+ */
+export function installCommandParts(pm: PackageManager = "npm"): { before: string; after: string } {
+  // "%SLUG%" can never appear in a real slug (kebab-case a-z0-9) or the rest of
+  // the command, so the split lands exactly where the slug goes.
+  const SENTINEL = "%SLUG%";
+  const [before, after] = installCommand(SENTINEL, pm).split(SENTINEL);
+  return { before, after };
+}
+
 /** The icon's AI prompt — a self-contained brief (glyph, motion, and the
  *  authoring contract) that an LLM can build the icon from.
  *

--- a/registry/icon-meta.gen.ts
+++ b/registry/icon-meta.gen.ts
@@ -180,6 +180,8 @@ export const iconMeta: IconMetaEntry[] = [
   { slug: "baseball", name: "Baseball", keywords: ["sport","ball","pitch","game","league","seams","strike","throw","spin","mitt"] },
   { slug: "baseball-cap", name: "Baseball Cap", keywords: ["hat","cap","sport","team","wear","clothing","brim","wind","gust","fashion"] },
   { slug: "baseball-helmet", name: "Baseball Helmet", keywords: ["sport","batting","batter","protection","gear","safety","dizzy","stars","team","wear"] },
+  { slug: "basket", name: "Basket", keywords: ["shopping","cart","market","groceries","store","buy","purchase","checkout","shop","items","carry"] },
+  { slug: "basketball", name: "Basketball", keywords: ["sport","ball","hoop","dribble","spin","court","game","nba","team","play"] },
 ];
 
 export const HOME_HIDDEN_SLUGS = new Set<string>(["bell","heart","star","bookmark","sun","arrow-right","bolt","moon","camera","trash","cloud","mail"]);

--- a/registry/icons/basket.tsx
+++ b/registry/icons/basket.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { forwardRef, useImperativeHandle } from "react";
+import { motion, type Variants } from "motion/react";
+import { useHover } from "@/hooks/use-hover";
+import { RETURN_TRANSITION } from "@/lib/motion-tokens";
+import type { IconHandle, IconProps } from "@/lib/icon";
+
+// SWING + HOP + SETTLE — one carry gesture with consequences. The basket
+// springs up with a stretch, swings like a pendulum while airborne (level again
+// before touchdown), lands with a squash — and the impact jostles the contents,
+// which drop and jiggle to rest a beat after landing. Three nested motions,
+// each about its own pivot: the hop about the base, the swing about the carry
+// handle's apex, the contents about their own feet.
+//
+// The Phosphor "shopping-basket" glyph splits into its own untouched subpaths:
+//   SHELL — the basket body, the ^ carry handle, and the top rim.
+//   GRIPS — the three rounded content lines inside the basket.
+// SHELL + GRIPS is byte-identical to the original path.
+const SHELL =
+  "M239.93,89.06,224.86,202.12A16.06,16.06,0,0,1,209,216H47a16.06,16.06,0,0,1-15.86-13.88L16.07,89.06A8,8,0,0,1,24,80H68.37L122,18.73a8,8,0,0,1,12,0L187.63,80H232a8,8,0,0,1,7.93,9.06ZM89.63,80h76.74L128,36.15ZM222.86,96H33.14L47,200H209Z";
+const GRIPS =
+  "M136,120v56a8,8,0,0,1-16,0V120a8,8,0,0,1,16,0Zm36.84-.8-5.6,56A8,8,0,0,0,174.4,184a7.32,7.32,0,0,0,.81,0,8,8,0,0,0,7.95-7.2l5.6-56a8,8,0,0,0-15.92-1.6Zm-89.68,0a8,8,0,0,0-15.92,1.6l5.6,56a8,8,0,0,0,8,7.2,7.32,7.32,0,0,0,.81,0,8,8,0,0,0,7.16-8.76Z";
+// Full original glyph (GRIPS + SHELL, in the original's subpath order), for the
+// reduced-motion static render.
+const BASKET = GRIPS + SHELL;
+
+const BASE = { transformBox: "view-box" as const, originX: 0.5, originY: 208 / 256 };
+const APEX = { transformBox: "view-box" as const, originX: 0.5, originY: 36 / 256 };
+const GRIP_FOOT = { transformBox: "view-box" as const, originX: 0.5, originY: 176 / 256 };
+
+const DUR = 1.3;
+
+// Bounds: the glyph top (handle apex, y≈16.7) must stay ≥0 under stretch-about-
+// the-base plus lift, or a clipping ancestor cuts the handle at the hop's peak.
+// scaleY 1.02 about y208 puts the top at 12.9; −12 lift lands it at 0.9.
+const hop: Variants = {
+  normal: { y: 0, scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    // Up fast, hang airborne through the middle (while the swing plays), then
+    // land with the squash and recover.
+    y: [0, -12, -11, -11, 0, 0],
+    scaleY: [1, 1.02, 1, 1, 0.9, 1],
+    scaleX: [1, 0.98, 1, 1, 1.07, 1],
+    transition: { duration: DUR, ease: "easeInOut", times: [0, 0.16, 0.24, 0.6, 0.78, 1] },
+  },
+};
+const swing: Variants = {
+  normal: { rotate: 0, transition: RETURN_TRANSITION },
+  animate: {
+    // Swings only while airborne (the middle of the timeline), level by landing.
+    rotate: [0, 0, -9, 7, -3.5, 0, 0],
+    transition: { duration: DUR, ease: "easeInOut", times: [0, 0.14, 0.3, 0.46, 0.6, 0.74, 1] },
+  },
+};
+const settle: Variants = {
+  normal: { y: 0, scaleY: 1, transition: RETURN_TRANSITION },
+  animate: {
+    // Triggered by touchdown: delay ≈ the hop's landing keyframe (DUR × 0.74).
+    y: [0, -4, 2, -1, 0],
+    scaleY: [1, 0.9, 1.05, 0.98, 1],
+    transition: { duration: 0.55, ease: "easeOut", times: [0, 0.25, 0.5, 0.75, 1], delay: DUR * 0.74 },
+  },
+};
+
+export const BasketIcon = forwardRef<IconHandle, IconProps>(
+  function BasketIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+
+    if (reduced) {
+      return (
+        <div {...props} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+          <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 256 256" fill="currentColor">
+            <path d={BASKET} />
+          </svg>
+        </div>
+      );
+    }
+
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 256 256"
+          fill="currentColor"
+          initial="normal"
+          animate={controls}
+          style={{ overflow: "visible" }}
+        >
+          <motion.g variants={hop} style={BASE}>
+            <motion.g variants={swing} style={APEX}>
+              <path d={SHELL} />
+              <motion.path d={GRIPS} variants={settle} style={GRIP_FOOT} />
+            </motion.g>
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);

--- a/registry/icons/basketball.tsx
+++ b/registry/icons/basketball.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { forwardRef, useImperativeHandle } from "react";
+import { motion, type Variants } from "motion/react";
+import { useHover } from "@/hooks/use-hover";
+import { RETURN_TRANSITION } from "@/lib/motion-tokens";
+import type { IconHandle, IconProps } from "@/lib/icon";
+
+// SPIN + BOUNCE — frame-studied from a reference clip that layers two
+// synchronized motions plus a flourish:
+//   bounce — pure deformation, no travel: tall stretch (wind-up), wide squash
+//            (contact) at mid-timeline, counter-stretch recovery, settle.
+//   spin   — one full revolution, launching after the wind-up and crossing
+//            180° right at the squash; single-segment on purpose — per-segment
+//            easing would halt the rotation at every keyframe (visible stutter).
+//   whips  — two arc streaks orbit just outside the rim on a lazier curve, so
+//            they lag the ball mid-flight like elastic tails and converge by
+//            the end; visible only while the spin is fast, gone at rest.
+//
+// The ball glyph is untouched Phosphor "basketball"; the streaks are extra ink
+// with opacity 0 in the normal state, so the rest render is pixel-identical.
+// Bounds (the wrapper clips): scaleY 1.08 about y232 puts the top at 7.4;
+// scaleX 1.12 puts the sides at 11.5/244.5. The streaks sit OUTSIDE the squash
+// group on purpose — squashed, their r120 outer edge would cross x=0;
+// undeformed they orbit at 8..248. Everything stays inside the 256 box.
+const BALL =
+  "M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24ZM60,72.17A87.2,87.2,0,0,1,79.63,120H40.37A87.54,87.54,0,0,1,60,72.17ZM136,120V40.37a87.59,87.59,0,0,1,48.68,20.37A103.06,103.06,0,0,0,160.3,120Zm-16,0H95.7A103.06,103.06,0,0,0,71.32,60.74,87.59,87.59,0,0,1,120,40.37ZM79.63,136A87.2,87.2,0,0,1,60,183.83,87.54,87.54,0,0,1,40.37,136Zm16.07,0H120v79.63a87.59,87.59,0,0,1-48.68-20.37A103.09,103.09,0,0,0,95.7,136Zm40.3,0h24.3a103.09,103.09,0,0,0,24.38,59.26A87.59,87.59,0,0,1,136,215.63Zm40.37,0h39.26A87.54,87.54,0,0,1,196,183.83,87.2,87.2,0,0,1,176.37,136Zm0-16A87.2,87.2,0,0,1,196,72.17,87.54,87.54,0,0,1,215.63,120Z";
+
+// Arcs of the r114 circle about (128,128): lower-left 100°→150°, upper-right
+// 280°→330° (θ increasing = clockwise in y-down coords, hence sweep=1).
+const STREAK_A = "M108.2,240.3 A114,114 0 0 1 29.3,185";
+const STREAK_B = "M147.8,15.7 A114,114 0 0 1 226.7,71";
+
+const FLOOR = { transformBox: "view-box" as const, originX: 0.5, originY: 232 / 256 };
+const CENTER = { transformBox: "view-box" as const, originX: 0.5, originY: 0.5 };
+
+const DUR = 1.25;
+
+const bounce: Variants = {
+  normal: { scaleY: 1, scaleX: 1, transition: RETURN_TRANSITION },
+  animate: {
+    scaleY: [1, 1.08, 1, 0.85, 1.04, 0.98, 1],
+    scaleX: [1, 0.94, 1, 1.12, 0.97, 1.01, 1],
+    transition: { duration: DUR, ease: "easeInOut", times: [0, 0.14, 0.3, 0.44, 0.62, 0.8, 1] },
+  },
+};
+const spin: Variants = {
+  normal: { rotate: 0, transition: { duration: 0 } },
+  animate: {
+    // ONE segment, one bezier: slow launch out of the wind-up, fastest through
+    // the middle (≈180° lands near the squash), long drain. Keyframing this
+    // would stop the rotation dead at every boundary.
+    rotate: [0, 360],
+    transition: { duration: DUR, ease: [0.55, 0.08, 0.25, 1] },
+  },
+};
+const trail: Variants = {
+  normal: { rotate: 0, transition: { duration: 0 } },
+  animate: {
+    rotate: [0, 360],
+    transition: { duration: DUR, ease: [0.72, 0.05, 0.22, 1] },
+  },
+};
+const streak: Variants = {
+  normal: { opacity: 0, pathLength: 0.3, transition: { duration: 0 } },
+  animate: {
+    // Whips exist only while the spin is fast: grow in, stretch long, snap out.
+    opacity: [0, 0, 1, 1, 0.6, 0],
+    pathLength: [0.15, 0.15, 1, 1, 0.4, 0.15],
+    transition: { duration: DUR, ease: "easeInOut", times: [0, 0.18, 0.32, 0.55, 0.72, 0.85] },
+  },
+};
+
+export const BasketballIcon = forwardRef<IconHandle, IconProps>(
+  function BasketballIcon({ size = 28, style, ...props }, ref) {
+    const { controls, reduced, start, stop, bind } = useHover();
+    useImperativeHandle(ref, () => ({ startAnimation: start, stopAnimation: stop }), [start, stop]);
+
+    if (reduced) {
+      return (
+        <div {...props} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+          <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 256 256" fill="currentColor">
+            <path d={BALL} />
+          </svg>
+        </div>
+      );
+    }
+
+    return (
+      <div {...props} {...bind} style={{ display: "inline-flex", overflow: "hidden", ...style }}>
+        <motion.svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={size}
+          height={size}
+          viewBox="0 0 256 256"
+          fill="currentColor"
+          initial="normal"
+          animate={controls}
+          style={{ overflow: "visible" }}
+        >
+          <motion.g variants={bounce} style={FLOOR}>
+            <motion.g variants={spin} style={CENTER}>
+              <path d={BALL} />
+            </motion.g>
+          </motion.g>
+          <motion.g variants={trail} style={CENTER}>
+            <motion.path d={STREAK_A} variants={streak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+            <motion.path d={STREAK_B} variants={streak} fill="none" stroke="currentColor" strokeWidth={12} strokeLinecap="round" />
+          </motion.g>
+        </motion.svg>
+      </div>
+    );
+  },
+);

--- a/registry/icons/index.ts
+++ b/registry/icons/index.ts
@@ -173,6 +173,8 @@ import { BarricadeIcon } from "./barricade";
 import { BaseballIcon } from "./baseball";
 import { BaseballCapIcon } from "./baseball-cap";
 import { BaseballHelmetIcon } from "./baseball-helmet";
+import { BasketIcon } from "./basket";
+import { BasketballIcon } from "./basketball";
 
 export type IconComponent = ForwardRefExoticComponent<IconProps & RefAttributes<IconHandle>>;
 
@@ -357,6 +359,8 @@ export const icons: IconEntry[] = [
   { slug: "baseball", name: "Baseball", keywords: ["sport", "ball", "pitch", "game", "league", "seams", "strike", "throw", "spin", "mitt"], Component: BaseballIcon },
   { slug: "baseball-cap", name: "Baseball Cap", keywords: ["hat", "cap", "sport", "team", "wear", "clothing", "brim", "wind", "gust", "fashion"], Component: BaseballCapIcon },
   { slug: "baseball-helmet", name: "Baseball Helmet", keywords: ["sport", "batting", "batter", "protection", "gear", "safety", "dizzy", "stars", "team", "wear"], Component: BaseballHelmetIcon },
+  { slug: "basket", name: "Basket", keywords: ["shopping", "cart", "market", "groceries", "store", "buy", "purchase", "checkout", "shop", "items", "carry"], Component: BasketIcon },
+  { slug: "basketball", name: "Basketball", keywords: ["sport", "ball", "hoop", "dribble", "spin", "court", "game", "nba", "team", "play"], Component: BasketballIcon },
 ];
 
 /** Slugs hidden from the public home page (still in the registry and installable). */

--- a/registry/lazy-icons.gen.tsx
+++ b/registry/lazy-icons.gen.tsx
@@ -169,6 +169,8 @@ export const LAZY_ICONS: Record<string, LazyIcon> = {
   "baseball": lazy(() => import("./icons/baseball").then((m) => ({ default: m.BaseballIcon }))),
   "baseball-cap": lazy(() => import("./icons/baseball-cap").then((m) => ({ default: m.BaseballCapIcon }))),
   "baseball-helmet": lazy(() => import("./icons/baseball-helmet").then((m) => ({ default: m.BaseballHelmetIcon }))),
+  "basket": lazy(() => import("./icons/basket").then((m) => ({ default: m.BasketIcon }))),
+  "basketball": lazy(() => import("./icons/basketball").then((m) => ({ default: m.BasketballIcon }))),
   "bell": lazy(() => import("./icons/bell").then((m) => ({ default: m.BellIcon }))),
   "bolt": lazy(() => import("./icons/bolt").then((m) => ({ default: m.BoltIcon }))),
   "bookmark": lazy(() => import("./icons/bookmark").then((m) => ({ default: m.BookmarkIcon }))),


### PR DESCRIPTION
Three hero touches, all built in the site's own design system (no Tailwind), each verified live in the browser.

## Rotating install command

The install command's icon slug now cycles through a curated set — `…/r/bell.json` → `heart` → `airplane` → … — so the CLI bar shows the library's breadth instead of one fixed icon. Inspired by lucide-animated.com's rotating command.

- **Only the slug animates**, rolling up in that icon's own glow colour; the rest of the command stays put.
- **Hover pauses the rotation** (reusing the border-beam hover signal), so you always copy exactly the icon you see — no swap can race the click.
- **Copy stays synced**: the current slug is threaded into the copy handler, so the copied command can never lag the shown one. Verified: shown `cloud` → copied `…/r/cloud.json`.
- **Reduced-motion safe**: frozen on one static, fully-copyable command.

**No layout shift.** The command box is pinned to the widest command in the rotation (GeistMono → 1 char = `1ch`), so nothing outside it moves — no width jitter per swap, and no wrap on the long `bunx --bun` prefix pushing the hero down. Inside, the slug slot glides between widths so `.json` follows smoothly rather than snapping. Measured across many swaps: bar width and the elements below it stay at a single constant value.

`installCommandParts()` splits the command around the slug, derived from `installCommand` via a sentinel, so the command format still lives in exactly one place.

## Footer attribution

"Crafted with Motion & Phosphor with ❤️" — the two projects Iconimate is built on, linking their repos ([motion](https://github.com/motiondivision/motion), [phosphor-icons/core](https://github.com/phosphor-icons/core)) — sits centered in the footer row as the space-between middle child.

## Also

Dropped the leading `$` prompt glyph from the install bar (and its orphaned CSS).

## Verification

- `pnpm verify` passes (0 errors, 13/13 tests).
- Zero console errors on a clean browser load.
- Confirmed live: rotation cycles, hover freezes it, cursor-leave resumes, copy matches the shown slug, six distinct glow colours across six slugs, and the `bun` (longest prefix) case stays single-line with constant width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
